### PR TITLE
Add support for subscribe decorator

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -26,6 +26,10 @@ def connect(client, flags, rc, properties):
     fast_mqtt.client.subscribe("/mqtt") #subscribing mqtt topic 
     print("Connected: ", client, flags, rc, properties)
 
+@fast_mqtt.subscribe("mqtt/+/temperature", "mqtt/+/humidity")
+async def home_message(client, topic, payload, qos, properties):
+    print("temperature/humidity: ", topic, payload.decode(), qos, properties)
+    return 0
 
 @fast_mqtt.on_message()
 async def message(client, topic, payload, qos, properties):

--- a/fastapi_mqtt/__init__.py
+++ b/fastapi_mqtt/__init__.py
@@ -1,8 +1,3 @@
-
-from fastapi_mqtt.fastmqtt import FastMQTT
-from fastapi_mqtt.config import  MQQTConfig
-
-
 __author__ = "Sabuhi Shukurov"
 
 __email__ = 'sabuhi.shukurov@gmail.com'
@@ -11,5 +6,9 @@ credits = ["Sabuhi Shukurov","Hasan Aliyev", "Tural Muradov"]
 
 __version__ = "0.0.5"
 
+from sys import modules as imported_modules
+if not "setuptools" in imported_modules.keys():
+    from fastapi_mqtt.fastmqtt import FastMQTT
+    from fastapi_mqtt.config import  MQQTConfig
 
-__all__ = ["FastMQTT", "MQQTConfig"]
+    __all__ = ["FastMQTT", "MQQTConfig"]


### PR DESCRIPTION
This commits brings fastapi_mqtt closer with interface to fastapi.
Because of this change user can now decorate specific functions
to be handlers for specific topic. Like this

```
@fast_mqtt.subscribe("mqtt/+/temperature")
async def handler(client, topic, payload, qos, properties):
    return 0
```

Handler can be registered for number of topics, need to pass
them all as comma separated arguments

```
@fast_mqtt.subscribe("topic1", "topic2")
```

Previous functionality stays unchanged.