### PR TITLE
chore: Deprecate MQQTConfig in favor of MQTTConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # fastapi-mqtt
 
-MQTT is a lightweight publish/subscribe messaging protocol designed for M2M (machine to machine) telemetry in low bandwidth environments. 
-Fastapi-mqtt  is the client for working with MQTT. 
+MQTT is a lightweight publish/subscribe messaging protocol designed for M2M (machine to machine) telemetry in low bandwidth environments.
+Fastapi-mqtt  is the client for working with MQTT.
 
-For more information about MQQT, please refer to here:  [MQTT](MQTT.md)
+For more information about MQTT, please refer to here:  [MQTT](MQTT.md)
 
-Fatapi-mqtt wraps around  [gmqtt](https://github.com/wialon/gmqtt) module. Gmqtt Python async client for MQTT client implementation. 
+Fatapi-mqtt wraps around  [gmqtt](https://github.com/wialon/gmqtt) module. Gmqtt Python async client for MQTT client implementation.
 Module has support of MQTT version 5.0 protocol
 
 
@@ -26,13 +26,13 @@ The key feature are:
 
 MQTT  specification avaliable with help decarator methods using callbacks:
 
--  on_connect() 
--  on_disconnect()  
--  on_subscribe()  
--  on_message()  
+-  on_connect()
+-  on_disconnect()
+-  on_subscribe()
+-  on_message()
 
-- Base Settings available with ```pydantic``` class 
-- Authetication to broker with credentials 
+- Base Settings available with ```pydantic``` class
+- Authetication to broker with credentials
 - unsubscribe certain topics and publish to certain topics
 
 ###  🔨  Installation ###
@@ -48,11 +48,11 @@ MQTT  specification avaliable with help decarator methods using callbacks:
 
 ```python
 from fastapi import FastAPI
-from fastapi_mqtt import FastMQTT, MQQTConfig
+from fastapi_mqtt import FastMQTT, MQTTConfig
 
 app = FastAPI()
 
-mqtt_config = MQQTConfig()
+mqtt_config = MQTTConfig()
 
 mqtt = FastMQTT(
     config=mqtt_config
@@ -68,7 +68,7 @@ async def shutdown():
 
 @mqtt.on_connect()
 def connect(client, flags, rc, properties):
-    mqtt.client.subscribe("/mqtt") #subscribing mqtt topic 
+    mqtt.client.subscribe("/mqtt") #subscribing mqtt topic
     print("Connected: ", client, flags, rc, properties)
 
 @mqtt.on_message()
@@ -88,7 +88,7 @@ def subscribe(client, mid, qos, properties):
 Publish method:
 ```python
 async def func():
-    await mqtt.publish("/mqtt", "Hello from Fastapi") #publishing mqtt topic 
+    await mqtt.publish("/mqtt", "Hello from Fastapi") #publishing mqtt topic
 
     return {"result": True,"message":"Published" }
 
@@ -98,13 +98,13 @@ Subscribe method:
 
 @mqtt.on_connect()
 def connect(client, flags, rc, properties):
-    mqtt.client.subscribe("/mqtt") #subscribing mqtt topic 
+    mqtt.client.subscribe("/mqtt") #subscribing mqtt topic
     print("Connected: ", client, flags, rc, properties)
 
 ```
 Changing connection params
 ```python
-mqtt_config = MQQTConfig(host = "mqtt.mosquito.org",
+mqtt_config = MQTTConfig(host = "mqtt.mosquito.org",
     port= 1883,
     keepalive = 60,
     username="username",

--- a/fastapi_mqtt/__init__.py
+++ b/fastapi_mqtt/__init__.py
@@ -9,6 +9,6 @@ __version__ = "0.1.0"
 from sys import modules as imported_modules
 if not "setuptools" in imported_modules.keys():
     from fastapi_mqtt.fastmqtt import FastMQTT
-    from fastapi_mqtt.config import  MQQTConfig
+    from fastapi_mqtt.config import  MQTTConfig, MQQTConfig
 
-    __all__ = ["FastMQTT", "MQQTConfig"]
+    __all__ = ["FastMQTT", "MQTTConfig", "MQQTConfig"]

--- a/fastapi_mqtt/config.py
+++ b/fastapi_mqtt/config.py
@@ -1,33 +1,34 @@
 from pydantic import  BaseSettings as Settings
 from gmqtt.mqtt.constants import MQTTv50
+from warnings import warn
 
 
-class MQQTConfig(Settings):
+class MQTTConfig(Settings):
     '''
-    MQQTConfig is main the configuration to be passsed client object.
+    MQTTConfig is main the configuration to be passsed client object.
 
-    host : To connect MQQT broker, defaults to localhost
-    port : To connect MQQT broker, defaults to 1883
+    host : To connect MQTT broker, defaults to localhost
+    port : To connect MQTT broker, defaults to 1883
 
     ssl : if given and not false, a SSL/TLS transport is created (by default a plain TCP transport is created)
         If ssl is a ssl.SSLContext object, this context is used to create the transport; if ssl is True, a default context returned from ssl.create_default_context() is used.
 
-    keepalive : Maximum period in seconds between communications with the broker. 
+    keepalive : Maximum period in seconds between communications with the broker.
         If no other messages are being exchanged, this controls the rate at which
         the client will send ping messages to the broker the keepalive timeout value for the client. Defaults to 60 seconds.
 
     username : username for authentication, defaults to None
     password : password for authentication, defaults to None
 
-    version : MQTT broker version to use, defaults to  MQTTv50. 
+    version : MQTT broker version to use, defaults to  MQTTv50.
         According to gmqtt.Client if your broker does not support 5.0 protocol version and responds with proper CONNACK reason code, client will downgrade to 3.1 and reconnect automatically.
 
-    reconnect_retries && reconnect_delay : By default, connected MQTT client will always try to reconnect in case of lost 
-        connections. Number of reconnect attempts is unlimited. 
-        If you want to change this behaviour pass reconnect_retries and reconnect_delay with its values. 
+    reconnect_retries && reconnect_delay : By default, connected MQTT client will always try to reconnect in case of lost
+        connections. Number of reconnect attempts is unlimited.
+        If you want to change this behaviour pass reconnect_retries and reconnect_delay with its values.
         For more info: # https://github.com/wialon/gmqtt#reconnects
 
-    # Last three parameters is used after client disconnects abnormally 
+    # Last three parameters is used after client disconnects abnormally
     param :: will_message_topic : Topic of the payload
     param :: will_message_payload : The payload
     param :: will_delay_interval : Delay interval
@@ -43,6 +44,10 @@ class MQQTConfig(Settings):
     reconnect_retries: int  = None
     reconnect_delay: int = None
 
-    will_message_topic: str = None 
-    will_message_payload: str = None 
+    will_message_topic: str = None
+    will_message_payload: str = None
     will_delay_interval: int = None
+
+
+class MQQTConfig(MQTTConfig):
+    warn("The MQQTConfig class is renamed MQTTConfig", DeprecationWarning, stacklevel=2)

--- a/fastapi_mqtt/fastmqtt.py
+++ b/fastapi_mqtt/fastmqtt.py
@@ -9,9 +9,9 @@ from typing import Any, Callable, Dict, Optional, Type, Union
 from gmqtt import Message
 from gmqtt import Client as MQTTClient
 from gmqtt.mqtt.constants import MQTTv311,MQTTv50
-from .config import MQQTConfig
+from .config import MQTTConfig
 try:
-    from uvicorn.config import logger 
+    from uvicorn.config import logger
     log_info = logger
 except:
     import logging
@@ -19,15 +19,15 @@ except:
 
 class FastMQTT:
     '''
-        FastMQTT client object to establish connection parametrs beforeconnect and manipulate MQTT service. 
-        
+        FastMQTT client object to establish connection parametrs beforeconnect and manipulate MQTT service.
+
         The class object holds session information necesseary to connect MQTT broker.
         ```
-        param :: config : MQQTConfig config class 
-        type  :: config: MQQTConfig
+        param :: config : MQTTConfig config class
+        type  :: config: MQTTConfig
         ```
         ```
-        param :: client_id : client_id  "should be unique identfiyer for connection to MQQT broker"
+        param :: client_id : client_id  "should be unique identfiyer for connection to MQTT broker"
         type  :: client_id: Any
         ```
         ```
@@ -45,10 +45,10 @@ class FastMQTT:
     '''
     def __init__(
         self,
-        config: MQQTConfig,  
-        *, 
+        config: MQTTConfig,
+        *,
         client_id:  Optional[Type[str]] = None,
-        clean_session: bool = True, 
+        clean_session: bool = True,
         optimistic_acknowledgement: bool = True,
         **kwargs: Any
     ) -> None:
@@ -73,12 +73,12 @@ class FastMQTT:
         self.handlers = dict()
         self.executor = ThreadPoolExecutor()
         self.loop = asyncio.get_event_loop()
-        
+
         log_info = logger
 
         if self.config.will_message_topic and self.config.will_message_payload and self.config.will_delay_interval:
             self.client._will_message = Message(
-                self.config.will_message_topic, 
+                self.config.will_message_topic,
                 self.config.will_message_payload,
                 self.config.will_delay_interval
             )
@@ -117,7 +117,7 @@ class FastMQTT:
         return False
 
     async def connection(self) -> None:
-        
+
         if self.client._username:
             self.client.set_auth_credentials(self.client._username, self.client._password)
             log_info.info("user is authenticated")
@@ -132,14 +132,14 @@ class FastMQTT:
 
     async def __set_connetion_config(self) -> None:
         '''
-            By default, connected MQTT client will always try to reconnect in case of lost connections. 
-            Number of reconnect attempts is unlimited. If you want to change this behaviour ass reconnect_retries and reconnect_delay with its values. 
+            By default, connected MQTT client will always try to reconnect in case of lost connections.
+            Number of reconnect attempts is unlimited. If you want to change this behaviour ass reconnect_retries and reconnect_delay with its values.
             For more info: # https://github.com/wialon/gmqtt#reconnects
         '''
-       
+
         if self.config.reconnect_retries:
             self.client.set_config(reconnect_retries=self.config.reconnect_retries)
-           
+
         if self.config.reconnect_delay:
             self.client.set_config(reconnect_delay=self.config.reconnect_delay)
 
@@ -193,11 +193,11 @@ class FastMQTT:
         '''
             Decarator method used to subscirbe messages from all topics.
         '''
-        
+
         def message_handler(handler: Callable) -> Callable:
             log_info.info("on_message handler accepted")
             self.user_message_handler = handler
-            
+
             return handler
 
         return message_handler
@@ -206,18 +206,18 @@ class FastMQTT:
     async def publish(self, message_or_topic: str, payload: Any = None, qos: int = 0, retain: bool = False, **kwargs):
         '''
             publish method
-        
+
             param :: message_or_topic : topic name
             type  :: message_or_topic:  str
-        
+
             param :: payload : message payload
             type  :: payload: Any
 
             param :: qos : Quality of Assuarance
-            type  :: qos:  
-            
-            param :: retain : 
-            type  :: retain:  
+            type  :: qos:
+
+            param :: retain :
+            type  :: retain:
         '''
 
         func = partial(self.client.publish, message_or_topic, payload=payload, qos=qos, retain=retain, **kwargs)
@@ -230,7 +230,7 @@ class FastMQTT:
             unsubscribe method
 
             param :: topic : topic name
-            type  :: str:  
+            type  :: str:
         '''
 
         func = partial(self.client.unsubscribe, topic, **kwargs)
@@ -239,7 +239,7 @@ class FastMQTT:
             del self.handlers[topic]
 
         return await self.loop.run_in_executor(self.executor, func)
-    
+
     def on_connect(self):
         '''
         Decarator method used to handle connection to MQTT.
@@ -247,12 +247,12 @@ class FastMQTT:
         def connect_handler(handler: Callable) -> Callable:
             log_info.info("handler accepted")
             self.user_connect_handler = handler
-                
+
             return handler
 
         return connect_handler
-    
-    
+
+
     def on_subscribe(self):
         '''
         Decarator method used to obtain subscibred topics and properties.
@@ -265,12 +265,12 @@ class FastMQTT:
 
         return subscribe_handler
 
-     
+
     def on_disconnect(self):
         '''
         Decarator method used wrap disconnet callback.
         '''
-        
+
         def disconnect_handler(handler: Callable) -> Callable:
             log_info.info("on_disconnect handler accepted")
             self.client.on_disconnect = handler


### PR DESCRIPTION
Calling `MQQTConfig` warns a DepreactionWarning.
I believe MQTTConfig was misspelled MQQTConfig. Closes #16.