### PR TITLE
Fix typing information in packaged version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     install_requires=["gmqtt>=0.6.8","uvicorn>=0.12.2", 'pydantic>=1.7.2',"fastapi>=0.61.2"],
     platforms=['any'],
     packages=setuptools.find_packages(),
-    package_data={"fastapi-mqtt": ["py.typed"]},
+    package_data={"fastapi_mqtt": ["py.typed"]},
     zip_safe=False,
     download_url="https://github.com/sabuhish/fastapi-mqtt",
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
### Problem
PR https://github.com/sabuhish/fastapi-mqtt/pull/26 added typing information. However, the wrong `package_data` was used in `setup.py`.

### Solution
This PR resolves this issue by updating the `package_data` in `setup.py`.

(Functionality stays unchanged)
