### PR TITLE
Add documentation for subscribe decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ MQTT specification avaliable with help decarator methods using callbacks:
 - on_disconnect()
 - on_subscribe()
 - on_message()
+- subscribe(topic)
 
 - Base Settings available with `pydantic` class
 - Authetication to broker with credentials
@@ -63,6 +64,10 @@ def connect(client, flags, rc, properties):
 @mqtt.on_message()
 async def message(client, topic, payload, qos, properties):
     print("Received message: ",topic, payload.decode(), qos, properties)
+
+@mqtt.subscribe("my/mqtt/topic/#")
+async def message_to_topic(client, topic, payload, qos, properties):
+    print("Received message to specific topic: ", topic, payload.decode(), qos, properties)
 
 @mqtt.on_disconnect()
 def disconnect(client, packet, exc=None):

--- a/docs/example.md
+++ b/docs/example.md
@@ -24,6 +24,10 @@ async def message(client, topic, payload, qos, properties):
     print("Received message: ",topic, payload.decode(), qos, properties)
     return 0
 
+@mqtt.subscribe("my/mqtt/topic/#")
+async def message_to_topic(client, topic, payload, qos, properties):
+    print("Received message to specific topic: ", topic, payload.decode(), qos, properties)
+
 @mqtt.on_disconnect()
 def disconnect(client, packet, exc=None):
     print("Disconnected")


### PR DESCRIPTION
Hello,

I really like your library, but I really missed the ability for topic specific handlers. I could only find that this feature was already implemented by digging into the source code. It is only used in the examples at a single point, but never mentioned in the readme or documentation.

Therefore I added documentation for the `subscribe` decorator to the readme and website. Hopefully this helps other users to find this feature more quickly.

Thanks for your work,

Jannik