### PR TITLE
Issue 46: Topic matching bugfix and unit tests

### DIFF
--- a/fastapi_mqtt/fastmqtt.py
+++ b/fastapi_mqtt/fastmqtt.py
@@ -97,17 +97,13 @@ class FastMQTT:
         topic = topic.split('/')
         template = template.split('/')
 
-        if len(topic) < len(template):
-            return False
-
         topic_idx = 0
-        for _, part in enumerate(template):
+        for part in template:
             if part == '#':
                 return True
-            elif part == '+' or part == topic[topic_idx]:
+            elif part in ['+', topic[topic_idx]]:
                 topic_idx += 1
-                continue
-            elif not part == topic[topic_idx]:
+            else:
                 return False
 
         if topic_idx == len(topic):

--- a/tests/test_topic_match.py
+++ b/tests/test_topic_match.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi_mqtt.fastmqtt import FastMQTT
+
+
+class TestTopicMatching:
+    matching = [
+        # pattern, topic, match
+        ("sport/tennis/player1", "sport/tennis/player1", True),
+
+        # wildcard "#"
+        ("sport/tennis/#", "sport/tennis/player1", True),
+        ("sport/tennis/#", "sport/tennis", True),
+        ("sport/#", "sport/tennis/player1", True),
+        ("#", "sport/tennis/player1", True),
+
+        # wildcard "+"
+        ("sport/+/player1", "sport/tennis/player1", True),
+        ("+/tennis/player1", "sport/tennis/player1", True),
+        ("sport/tennis/+", "sport/tennis/player1", True),
+
+        # both wildcards
+        ("sport/+/#", "sport/tennis/player1", True),
+
+        # leading $ and /
+        ("$SYS/state", "$SYS/state", True),
+        ("$SYS/#", "$SYS/state", True),
+        ("/foo/bar", "/foo/bar", True),
+        ("/#", "/foo/bar", True),
+
+        # non-matching
+        ("sport/tennis/player1", "sport/tennis/player1/ranking", False),
+        ("sport/tennis/player1", "sport/tennis/player2", False),
+        ("sport/+/player1", "sport/tennis/player2", False),       
+    ]
+
+    @pytest.mark.parametrize(argnames=["pattern", "topic", "match"], argvalues=matching)
+    def test_matching(self, topic: str, pattern: str, match: bool) -> None:
+        assert match == FastMQTT.match(topic=topic, template=pattern)


### PR DESCRIPTION
Updates the `FastMQTT.match()` algorithm to be compliant with the [specification](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html).

Also added unit tests, but I haven't created github actions to automate running the tests.