### PR TITLE
mkdocs: fix typo in title

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ nav:
   - 🕹 Getting Started: getting-started.md
   - Example: example.md
   - MQTT: mqtt.md
-  - Contirbution: contribute.md
+  - Contribution: contribute.md
 
 
 


### PR DESCRIPTION
This PR fixes a typo in the title of the contribution section in the documentation.