### PR TITLE
Fix the last will message functionality

### DIFF
--- a/fastapi_mqtt/config.py
+++ b/fastapi_mqtt/config.py
@@ -54,4 +54,4 @@ class MQTTConfig(Settings):
 
     will_message_topic: Optional[str] = None
     will_message_payload: Optional[str] = None
-    will_delay_interval: Optional[str] = None
+    will_delay_interval: Optional[int] = None

--- a/fastapi_mqtt/fastmqtt.py
+++ b/fastapi_mqtt/fastmqtt.py
@@ -79,7 +79,7 @@ class FastMQTT:
             self.client._will_message = Message(
                 self.config.will_message_topic,
                 self.config.will_message_payload,
-                self.config.will_delay_interval,
+                will_delay_interval=self.config.will_delay_interval,
             )
             log_info.debug(
                 f'topic -> {self.config.will_message_topic} \n payload -> {self.config.will_message_payload} \n will_delay_interval -> {self.config.will_delay_interval}'  # noqa E501


### PR DESCRIPTION
Minor changes to fix #53.

Example now runs ok:

Fixes #53 

```
❯ uvicorn examples.app_will_message:app --reload --log-level debug
INFO:     Will watch for changes in these directories: ['/Users/user/github/fastapi-mqtt']
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [6475] using StatReload
DEBUG:    topic -> /WILL
 payload -> MQTT Connection is dead!
 will_delay_interval -> 2
DEBUG:    WILL MESSAGE INITIALIZED
DEBUG:    handler accepted
INFO:     on_connect handler accepted
DEBUG:    on_message handler accepted
INFO:     on_message handler accepted
DEBUG:    on_disconnect handler accepted
DEBUG:    on_subscribe handler accepted
INFO:     on_subscribe handler accepted
INFO:     Started server process [6478]
INFO:     Waiting for application startup.
WARNING:  Used broker version is 5
Connected:  <gmqtt.client.Client object at 0x106984760> 0 0 {'topic_alias_maximum': [10], 'receive_maximum': [20]}
DEBUG:    connected to broker..
INFO:     Application startup complete.
subscribed <gmqtt.client.Client object at 0x106984760> 1 (0,) {}
subscribed <gmqtt.client.Client object at 0x106984760> 2 (0,) {}
```