### PR TITLE
Use pydantic BaseModel for MQTTConfig object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ MQTT specification avaliable with help decarator methods using callbacks:
 - on_message()
 - subscribe(topic)
 
-- Base Settings available with `pydantic` class
-- Authetication to broker with credentials
+- MQTT Settings available with `pydantic` class
+- Authentication to broker with credentials
 - unsubscribe certain topics and publish to certain topics
 
 ### 🔨 Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ MQTT specification avaliable with help decarator methods using callbacks:
 - `on_subscribe() `
 - `on_message() `
 
-Base Settings available with `pydantic` class:
+MQTT Settings available with `pydantic` class:
 
-- `Authetication` to broker with credentials
+- `Authentication` to broker with credentials
 - `unsubscribe` certain topics and `publish` to certain topics

--- a/fastapi_mqtt/config.py
+++ b/fastapi_mqtt/config.py
@@ -2,10 +2,10 @@ from ssl import SSLContext
 from typing import Optional, Union
 
 from gmqtt.mqtt.constants import MQTTv50
-from pydantic import BaseSettings as Settings
+from pydantic import BaseModel
 
 
-class MQTTConfig(Settings):
+class MQTTConfig(BaseModel):
     """
     MQTTConfig is main the configuration to be passed client object.
 
@@ -55,3 +55,6 @@ class MQTTConfig(Settings):
     will_message_topic: Optional[str] = None
     will_message_payload: Optional[str] = None
     will_delay_interval: Optional[int] = None
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -917,4 +917,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "82371c2e2a396c81bf10a2456aa37716f9d8ce527c1499939235cc522c041f75"
+content-hash = "99e4e413fd552ae46bd1211f903f9bf74cdb12be772d3b1ef2a4f60bee1b19b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-mqtt"
-version = "1.0.7"
+version = "1.2.0"
 description = "fastapi-mqtt is extension for MQTT protocol"
 authors = ["sabuhish <sabuhi.shukurov@gmail.com>"]
 license = "MIT"
@@ -21,11 +21,11 @@ classifiers = [
 python = "^3.7"
 fastapi = "0.*"
 gmqtt = "^0.6.11"
-pydantic = "^1.9.0"
+pydantic = ">=1.10.0"
 uvicorn = ">=0.19.0"
-black = "^23.3.0"
 
 [tool.poetry.dev-dependencies]
+black = "^23.3.0"
 isort = "^5.10.1"
 flake8 = "^4.0.1"
 mypy = "^0.942"


### PR DESCRIPTION
Rework of #62, as a result of the discussion in #68

cc @sabuhish @tim-timman @mblo

#### Changes:

- ♻️ Use Pydantic's **`BaseModel` for `MQTTConfig`**, instead of `BaseSettings`
- 📦️ Bump version to **v1.2.0**, and require `pydantic>=1.10`, making it compatible with v2 (it will emit just a warning about `ConfigDict`)
- ✏️ Minor formatting changes and typos