### PR TITLE
Fix wrong reference to fastapi-mail and typos in contributing.md

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -21,15 +21,12 @@ Please refer to each project's style and contribution guidelines for submitting 
  4. **Push** your work 
  5. Submit a **Pull request** so that we can review your changes
 
-<!-- FIXME: What does this title mean? I dont get it :P-->
-### Before get in to the repo and type
-
+## Before contributing, here is how to install
 
 ```sh
-$ bash install.sh   
+$ bash scripts/install.sh
 $ source .venv/bin/activate
 $ cat main.py
-or
 
 ```
 or run fastapi app with uvicorn

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -32,7 +32,7 @@ $ cat main.py
 or
 
 ```
-or run fastapi app with uvicron
+or run fastapi app with uvicorn
 
 ```sh
 uvicorn app:app --port 8000 --reload

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,14 +1,14 @@
-Contributing to fastapi-mail
+Contributing to fastapi-mqtt
 =========================================
 
-We welcome contributions to [fastapi-mail](https://github.com/sabuhish/fastapi-mail)
+We welcome contributions to [fastapi-mqtt](https://github.com/sabuhish/fastapi-mqtt)
 
 Issues
 ------
 
 Feel free to submit issues and enhancement requests.
 
-[Fatapi-Mail Issues](https://github.com/sabuhish/fastapi-mail/issues)
+[Fastapi-MQTT Issues](https://github.com/sabuhish/fastapi-mqtt/issues)
 
 Contributing
 ------------
@@ -21,7 +21,7 @@ Please refer to each project's style and contribution guidelines for submitting 
  4. **Push** your work 
  5. Submit a **Pull request** so that we can review your changes
 
-
+<!-- FIXME: What does this title mean? I dont get it :P-->
 ### Before get in to the repo and type
 
 


### PR DESCRIPTION
`contributing.md` talked about `fastapi-mail` instead of  `fastapi-mqtt`. That was fixed by changing the text and updating the urls

Also, the `### Before get in to the repo and type` section looks a bit weird, i dont understand the purpose. Maybe it had sense in `fastapi-mail`?