### PR TITLE
🎨 Add explicit async methods for fastapi app lifespan

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 MQTT is a lightweight publish/subscribe messaging protocol designed for M2M (machine to machine) telemetry in low bandwidth environments.
 Fastapi-mqtt is the client for working with MQTT.
 
-For more information about MQQT, please refer to here: [MQTT](mqtt.md)
+For more information about MQTT, please refer to here: [MQTT](mqtt.md)
 
 Fatapi-mqtt wraps around [gmqtt](https://github.com/wialon/gmqtt) module. Gmqtt Python async client for MQTT client implementation.
 The module has the support of MQTT version 5.0 protocol

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,10 +33,10 @@ def test_app():
 
     @asynccontextmanager
     async def _lifespan(application: FastAPI):
-        await fast_mqtt.connection()
+        await fast_mqtt.mqtt_startup()
         logging.info("connection done, starting fastapi app now")
         yield
-        await fast_mqtt.client.disconnect()
+        await fast_mqtt.mqtt_shutdown()
 
     app = FastAPI(lifespan=_lifespan)
 


### PR DESCRIPTION
related to #77, for more explicit support of the **fastapi lifespan** system

cc @sabuhish, @ChrsPi 

### Changes

- 🎨 Add explicit async methods for fastapi app lifespan, in addition to legacy `init_app` method, and use them in the `test_app` fixture
- ✏️ Fix typo in docs