### PR TITLE
fix: Correct behaviour of shared subscriptions

### DIFF
--- a/fastapi_mqtt/fastmqtt.py
+++ b/fastapi_mqtt/fastmqtt.py
@@ -94,6 +94,9 @@ class FastMQTT:
         topic: topic name
         template: template topic name that contains wildcards
         """
+        if str(template).startswith("$share/"):
+            template=template.split("/", 2)[2]
+
         topic = topic.split("/")
         template = template.split("/")
 

--- a/tests/test_topic_match.py
+++ b/tests/test_topic_match.py
@@ -38,6 +38,12 @@ class TestTopicMatching:
         ("+/tennis", "anything/golf", False),
         ("#", "$SYS/anything", False),
         ("+/monitor/Clients", "$SYS/monitor/Clients", False),
+
+        # According to MQTT5.0 item 4.8.2
+        ("$share/myshare/Clients/anything", "Clients/anything", True),
+        ("$share/myshare/Clients/+", "Clients/anything", True),
+        ("$share/myshare//finance", "/finance", True),
+        ("$share/myshare//finance", "finance", False),
     ]
 
     @pytest.mark.parametrize(argnames=["pattern", "topic", "match"], argvalues=matching)


### PR DESCRIPTION
According to [MQTT5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html)  item 4.8.2

> A Shared Subscription is identified using a special style of Topic Filter. The format of this filter is:
> $share/{ShareName}/{filter}

So a message with a topic ``sport/tennis/ball`` should match ``$share/consumer1/sport/tennis/+``

Currently no shared topics work properly.