### PR TITLE
🥚 Add example app with websocket endpoint and dynamic MQTT subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ __pycache__/
 # C extensions
 *.so
 .vscode/
-app.py
 test.txt
 # Distribution / packaging
 .Python

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ mqtt = FastMQTT(config=mqtt_config)
 docker run -d --name mosquitto -p 9001:9001 -p 1883:1883 eclipse-mosquitto:1.6.15
 # Set host for test broker when running pytest
 TEST_BROKER_HOST=localhost pytest
-# Run example app against local broker
+# Run the example apps against local broker, with uvicorn
 TEST_BROKER_HOST=localhost uvicorn examples.app:app --port 8000 --reload
+TEST_BROKER_HOST=localhost uvicorn examples.ws_app.app:application --port 8000 --reload
 ```
 
 # Contributing

--- a/docs/example.md
+++ b/docs/example.md
@@ -43,3 +43,8 @@ async def func():
 
     return {"result": True,"message":"Published" }
 ```
+
+### More complex examples
+
+Visit the [examples](https://github.com/sabuhish/fastapi-mqtt/tree/master/examples) folder for more code examples,
+including a full fastAPI app organized in multiple files (splitting dependencies, routes, app creation) implementing a **dynamic MQTT client** through a WebSocket connection.

--- a/examples/ws_app/app.py
+++ b/examples/ws_app/app.py
@@ -1,0 +1,67 @@
+import os
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from uvicorn.config import logger
+
+from fastapi_mqtt.config import MQTTConfig
+from fastapi_mqtt.fastmqtt import FastMQTT
+
+from .mqtt_ws_client import DynamicMQTTClient
+from .router import mqtt_router
+
+# NOTE: Need to `pip install websockets` to make it work,
+# or a 'No supported WebSocket library detected' warning will appear.
+
+# Run MQTT broker in background for tests with:
+# `docker run -d --name mosquitto -p 9001:9001 -p 1883:1883 eclipse-mosquitto:1.6.15`
+TEST_BROKER_HOST = os.getenv("TEST_BROKER_HOST", default="localhost")
+
+
+def create_app():
+    """Example fastAPI app with dynamic MQTT client."""
+    fast_mqtt = FastMQTT(config=MQTTConfig(host=TEST_BROKER_HOST))
+
+    ws_subscribers = DynamicMQTTClient(fast_mqtt)
+
+    @asynccontextmanager
+    async def _lifespan(application: FastAPI):
+        await fast_mqtt.mqtt_startup()
+        application.state.ws_subscribers = ws_subscribers
+        yield
+        await ws_subscribers.close()
+        await fast_mqtt.mqtt_shutdown()
+
+    app = FastAPI(lifespan=_lifespan)
+
+    @fast_mqtt.on_message()
+    async def _process_message(_client, topic, payload, qos, properties):
+        """
+        Common method to dispatch all received MQTT messages.
+
+        If there are multiple subscriptions that match the same topic of the
+        received message, this method will be called multiple times.
+
+        Example:
+             * Client is subscribed to 'test/#' and 'test/hello/+'
+             * Broker receives a message with topic 'test/hello/there'
+             * This method is called 2 times with the same topic and payload,
+               **one for each topic match** in the client subscriptions.
+        """
+        num_clients_send_to = await ws_subscribers.send_mqtt_msg(fast_mqtt, topic, payload.decode())
+        logger.info(
+            "Received message: %s '%s' QoS=%s properties=%s. Broadcasted to %d ws clients",
+            topic,
+            payload.decode(),
+            qos,
+            properties,
+            num_clients_send_to,
+        )
+        return num_clients_send_to
+
+    app.include_router(mqtt_router)
+
+    return app
+
+
+application = create_app()

--- a/examples/ws_app/dependencies.py
+++ b/examples/ws_app/dependencies.py
@@ -1,0 +1,19 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request, WebSocket
+
+from .mqtt_ws_client import DynamicMQTTClient
+
+mqtt_router = APIRouter()
+
+
+async def _get_ws_subscribers(request: Request) -> DynamicMQTTClient:
+    return request.app.state.ws_subscribers
+
+
+async def _get_ws_subscribers_from_ws(websocket: WebSocket) -> DynamicMQTTClient:
+    return websocket.app.state.ws_subscribers
+
+
+Clients = Annotated[DynamicMQTTClient, Depends(_get_ws_subscribers)]
+WSClients = Annotated[DynamicMQTTClient, Depends(_get_ws_subscribers_from_ws)]

--- a/examples/ws_app/mqtt_ws_client.py
+++ b/examples/ws_app/mqtt_ws_client.py
@@ -1,0 +1,110 @@
+import asyncio
+from asyncio import Queue
+from contextlib import contextmanager
+from typing import AsyncGenerator, cast, Generator
+
+from gmqtt import Subscription
+from uvicorn.config import logger
+
+from fastapi_mqtt.fastmqtt import FastMQTT
+
+
+class DynamicMQTTClient:
+    """
+    Wrapper around FastMQTT manager to dynamically subscribe to MQTT topics
+
+    Supporting multiple persistent connections (like websockets or SSE),
+    so the MQTT client is subscribed to a certain topic only when at least
+    one client is listening to MQTT messages on it.
+
+    If multiple clients _subscribe_ to the same topic,
+    the subscription is shared and all clients are notified on new messages
+    that match the subscribed topic.
+
+    Inpired by the `MultisubscriberQueue` in
+    https://github.com/smithk86/asyncio-multisubscriber-queue
+    """
+
+    mqtt: FastMQTT
+    topic_subscriptions: dict[str, set[Queue[str]]]
+    _close_sentinel = cast(str, object())
+
+    __slots__ = ("mqtt", "topic_subscriptions")
+
+    def __init__(self, mqtt: FastMQTT) -> None:
+        self.mqtt = mqtt
+        self.topic_subscriptions = {}
+
+    async def subscribe(
+        self,
+        topic: str,
+        qos: int = 0,
+        no_local: bool = False,
+        retain_as_published: bool = False,
+        retain_handling_options: int = 0,
+    ) -> AsyncGenerator[str, None]:
+        """Async generator to subscribe to MQTT topic and receive messages."""
+        with self.queue(topic, qos, no_local, retain_as_published, retain_handling_options) as q:
+            while True:
+                _data: str = await q.get()
+                if _data is self._close_sentinel:
+                    break
+                yield _data
+
+    @contextmanager
+    def queue(
+        self,
+        topic: str,
+        qos: int,
+        no_local: bool,
+        retain_as_published: bool,
+        retain_handling_options: int,
+    ) -> Generator[Queue[str], None, None]:
+        """Context helper which manages the lifecycle of the Queue."""
+        _queue: Queue[str] = Queue()
+        if topic in self.topic_subscriptions:
+            self.topic_subscriptions[topic].add(_queue)
+        else:
+            self.topic_subscriptions[topic] = {_queue}
+            subscription = Subscription(
+                topic,
+                qos,
+                no_local,
+                retain_as_published,
+                retain_handling_options,
+            )
+            logger.warning("Subscribing to %s -> %s", subscription.topic, subscription)
+            self.mqtt.client.subscribe(subscription)
+        try:
+            yield _queue
+        finally:
+            self.topic_subscriptions[topic].remove(_queue)
+            if not self.topic_subscriptions[topic]:
+                self.topic_subscriptions.pop(topic)
+                logger.warning("UnSubscribing from %s", topic)
+                self.mqtt.client.unsubscribe(topic)
+
+    async def send_mqtt_msg(self, mqtt: FastMQTT, topic: str, msg_payload: str) -> int:
+        """Put data on all the Queues matching the topic."""
+        tasks = []
+        for topic_listen, queues in self.topic_subscriptions.items():
+            if mqtt.match(topic, topic_listen):
+                tasks.extend(
+                    [
+                        _queue.put(f"Msg received in topic '{topic}':\n{msg_payload}")
+                        for _queue in queues
+                    ]
+                )
+        if tasks:
+            await asyncio.gather(*tasks)
+        return len(tasks)
+
+    async def close(self) -> None:
+        """Put the close sentinel on all the Queues to signal session end."""
+        await asyncio.gather(
+            *[
+                _queue.put(self._close_sentinel)
+                for queues in self.topic_subscriptions.values()
+                for _queue in queues
+            ]
+        )

--- a/examples/ws_app/router.py
+++ b/examples/ws_app/router.py
@@ -1,0 +1,87 @@
+import asyncio
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+from uvicorn.config import logger
+
+from .dependencies import Clients, WSClients
+
+mqtt_router = APIRouter()
+
+_HTML_WS_MQTT_CLIENT = """<!DOCTYPE html>
+<html>
+    <head>
+        <title>MQTT WebSocket Client</title>
+    </head>
+    <body>
+        <h1>WebSocket Dynamic MQTT client</h1>
+        <form action="" onsubmit="sendMessage(event)">
+            <input type="text" id="topicText" autocomplete="off"/>
+            <button>Subscribe to topic</button>
+        </form>
+        <ul id='messages'>
+        </ul>
+        <script>
+            var ws = new WebSocket(`ws://localhost:8000/ws-mqtt-client`);
+            ws.onmessage = function(event) {
+                var messages = document.getElementById('messages');
+                var message = document.createElement('li');
+                var content = document.createTextNode(event.data);
+                message.appendChild(content);
+                messages.appendChild(message);
+            };
+            function sendMessage(event) {
+                var input = document.getElementById("topicText");
+                ws.send(input.value);
+                input.value = '';
+                event.preventDefault();
+            }
+        </script>
+    </body>
+</html>
+"""
+
+
+@mqtt_router.get("/home")
+async def _ws_demo_page():
+    """Show basic web with websocket connection to subscribe to MQTT topics."""
+    return HTMLResponse(_HTML_WS_MQTT_CLIENT)
+
+
+@mqtt_router.get("/ws-subscriptions")
+async def _get_current_clients_subscriptions(ws_subscribers: Clients):
+    """Return JSON with current state of WS clients."""
+    return {
+        "topic_subscriptions": list(ws_subscribers.topic_subscriptions.keys()),
+        "clients_by_topic": {
+            key: len(queues) for key, queues in ws_subscribers.topic_subscriptions.items()
+        },
+    }
+
+
+@mqtt_router.websocket("/ws-mqtt-client")
+async def websocket_endpoint(websocket: WebSocket, ws_subscribers: WSClients):
+    await websocket.accept()
+    logger.info("WS connected")
+
+    async def _send_received_msgs(topic):
+        async for msg in ws_subscribers.subscribe(topic):
+            await websocket.send_text(msg)
+
+    try:
+        data_topic = await websocket.receive_text()
+        logger.warning("WS MQTT subscription to '%s'", data_topic)
+
+        await websocket.send_text(f"You subscribed to: {data_topic}")
+        while True:
+            # in separate task, listen to received MQTT messages
+            task_push_msg = asyncio.create_task(
+                _send_received_msgs(data_topic),
+            )
+            # while waiting for new WS socket for new MQTT subscription
+            data_topic = await websocket.receive_text()
+            task_push_msg.cancel()
+            logger.warning("WS MQTT subscription change to '%s'", data_topic)
+            await websocket.send_text(f"You subscribed to: {data_topic}")
+    except WebSocketDisconnect:
+        logger.info("Closed tab")


### PR DESCRIPTION
closes #52, #71

Add a 3rd fastAPI app example, showing the following:

- App **split in submodules**, with separate router, usage of `Depends`, etc.
- App **_Lifespan_ usage**
- **Websocket** endpoint to **dynamically subscribe** to topics and receive MQTT messages, as a _wrapper_ over `FastMQTT` 

Usage with:

```shell
# install websockets if necessary
pip install websockets
# run example app
uvicorn examples.ws_app.app:application --port 8000
# and navigate to http://localhost:8000/home
```

cc @MoonCactus, @sabuhish